### PR TITLE
Add OnEnd and OnEndArgumentList parameters to Enter-RSSession

### DIFF
--- a/Examples/StartBinaryModuleDevelopment.ps1
+++ b/Examples/StartBinaryModuleDevelopment.ps1
@@ -19,4 +19,4 @@ $onStart = {
     Start-RSRestartFileWatcher -Path $projectDir -IncludeSubdirectories
 }
 
-Enter-RSSession -OnStart $onStart -ArgumentList $DotNetProjectDirectory, $DllPath -ShowProcessId
+Enter-RSSession -OnStart $onStart -OnStartArgumentList $DotNetProjectDirectory, $DllPath -ShowProcessId

--- a/Examples/StartScriptModuleDevelopment.ps1
+++ b/Examples/StartScriptModuleDevelopment.ps1
@@ -15,4 +15,4 @@ $onStart = {
     Start-RSRestartFileWatcher -Path $dir -IncludeSubdirectories
 }
 
-Enter-RSSession -OnStart $onStart -ArgumentList $ModuleDirectory -ShowProcessId
+Enter-RSSession -OnStart $onStart -OnStartArgumentList $ModuleDirectory -ShowProcessId

--- a/RestartableSession/Private/Variables.ps1
+++ b/RestartableSession/Private/Variables.ps1
@@ -12,7 +12,9 @@ public class GlobalVariable
 
     public static bool IsDevMode = false;
     public static string PromptPrefix = "";
-    public static ScriptBlock OriginalPromptFunction;
+    public static ScriptBlock OriginalPromptFunction = null;
+    public static ScriptBlock OnEnd = null;
+    public static System.Object[] OnEndArgumentList = null;
 
     public static bool IsInRestartableSession()
     {

--- a/RestartableSession/Public/Enter-RSSession.ps1
+++ b/RestartableSession/Public/Enter-RSSession.ps1
@@ -36,15 +36,26 @@ Enter-RSSession -OnStart $onStart -ArgumentList D:\ScriptModuleTest
 #>
 function Enter-RSSession
 {
-    [CmdletBinding(DefaultParameterSetName='NoOnStart')]
+    [CmdletBinding(DefaultParameterSetName='Default')]
     param
     (
-        [Parameter(ParameterSetName='NoOnStart', Mandatory=$false, ValueFromPipelineByPropertyName=$true)]
+        [Parameter(ParameterSetName='Default', Mandatory=$false, ValueFromPipelineByPropertyName=$true)]
         [Parameter(ParameterSetName='OnStart', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+        [Parameter(ParameterSetName='OnStartOnEnd', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
         [ScriptBlock]$OnStart,
 
         [Parameter(ParameterSetName='OnStart', ValueFromPipelineByPropertyName=$true)]
+        [Parameter(ParameterSetName='OnStartOnEnd', ValueFromPipelineByPropertyName=$true)]
         [Object[]]$ArgumentList,
+
+        [Parameter(ParameterSetName='Default', Mandatory=$false, ValueFromPipelineByPropertyName=$true)]
+        [Parameter(ParameterSetName='OnEnd', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+        [Parameter(ParameterSetName='OnStartOnEnd', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+        [ScriptBlock]$OnEnd,
+
+        [Parameter(ParameterSetName='OnEnd', ValueFromPipelineByPropertyName=$true)]
+        [Parameter(ParameterSetName='OnStartOnEnd', ValueFromPipelineByPropertyName=$true)]
+        [Object[]]$OnEndArgumentList,
 
         [Parameter(ValueFromPipelineByPropertyName=$true)]
         [Switch]$ShowProcessId
@@ -103,6 +114,12 @@ function Enter-RSSession
                     Invoke-Command -ScriptBlock ([ScriptBlock]::Create($args.onStart)) -NoNewScope
                 }
             }
+
+            if ($args.onEnd)
+            {
+                [RestartableSession.GlobalVariable]::OnEnd = [ScriptBlock]::Create($args.onEnd)
+                [RestartableSession.GlobalVariable]::OnEndArgumentList = $args.onEndArgumentList
+            }
         }
 
         $restartCount = 1
@@ -114,6 +131,8 @@ function Enter-RSSession
                 showProcessId = ($ShowProcessId -eq $true)
                 onStart = $OnStart
                 onStartArgumentList = $ArgumentList
+                onEnd = $OnEnd
+                onEndArgumentList = $OnEndArgumentList
             }
 
             & $powershellExe -NoExit -Command $command -Args $arguments

--- a/RestartableSession/Public/Enter-RSSession.ps1
+++ b/RestartableSession/Public/Enter-RSSession.ps1
@@ -9,8 +9,14 @@ The PowerShell executable that called this function is used to create a new sess
 .PARAMETER OnStart
 ScriptBlock that is called at the start of the restartable session.
 
-.PARAMETER ArgumentList
+.PARAMETER OnStartArgumentList
 An array of arguments that is passed to the OnStart script block.
+
+.PARAMETER OnEnd
+ScriptBlock that is called at the end of the restartable session.
+
+.PARAMETER OnEndArgumentList
+An array of arguments that is passed to the OnEnd script block.
 
 .PARAMETER ShowProcessId
 Switch to specify if the process ID of the restartable session is shown in the prompt.
@@ -31,7 +37,7 @@ $onStart = {
     Import-Module $modulePath
     Start-RSRestartFileWatcher -Path $modulePath -IncludeSubdirectories
 }
-Enter-RSSession -OnStart $onStart -ArgumentList D:\ScriptModuleTest
+Enter-RSSession -OnStart $onStart OnStartArgumentList D:\ScriptModuleTest
 
 #>
 function Enter-RSSession

--- a/RestartableSession/Public/Enter-RSSession.ps1
+++ b/RestartableSession/Public/Enter-RSSession.ps1
@@ -46,7 +46,8 @@ function Enter-RSSession
 
         [Parameter(ParameterSetName='OnStart', ValueFromPipelineByPropertyName=$true)]
         [Parameter(ParameterSetName='OnStartOnEnd', ValueFromPipelineByPropertyName=$true)]
-        [Object[]]$ArgumentList,
+        [Alias('ArgumentList')]
+        [Object[]]$OnStartArgumentList,
 
         [Parameter(ParameterSetName='Default', Mandatory=$false, ValueFromPipelineByPropertyName=$true)]
         [Parameter(ParameterSetName='OnEnd', Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
@@ -130,7 +131,7 @@ function Enter-RSSession
                 modulePath = $modulePath
                 showProcessId = ($ShowProcessId -eq $true)
                 onStart = $OnStart
-                onStartArgumentList = $ArgumentList
+                onStartArgumentList = $OnStartArgumentList
                 onEnd = $OnEnd
                 onEndArgumentList = $OnEndArgumentList
             }

--- a/RestartableSession/Public/Enter-RSSession.ps1
+++ b/RestartableSession/Public/Enter-RSSession.ps1
@@ -37,7 +37,7 @@ $onStart = {
     Import-Module $modulePath
     Start-RSRestartFileWatcher -Path $modulePath -IncludeSubdirectories
 }
-Enter-RSSession -OnStart $onStart OnStartArgumentList D:\ScriptModuleTest
+Enter-RSSession -OnStart $onStart -OnStartArgumentList D:\ScriptModuleTest
 
 #>
 function Enter-RSSession

--- a/RestartableSession/Public/Exit-RSSession.ps1
+++ b/RestartableSession/Public/Exit-RSSession.ps1
@@ -24,6 +24,10 @@ function Exit-RSSession
     {
         if ([RestartableSession.GlobalVariable]::IsInRestartableSession())
         {
+            if ([RestartableSession.GlobalVariable]::OnEnd)
+            {
+                [RestartableSession.GlobalVariable]::OnEnd.Invoke([RestartableSession.GlobalVariable]::OnEndArgumentList)
+            }
             exit [RestartableSession.GlobalVariable]::kExitCodeToBreak
         }
         else

--- a/RestartableSession/Public/Restart-RSSession.ps1
+++ b/RestartableSession/Public/Restart-RSSession.ps1
@@ -26,6 +26,10 @@ function Restart-RSSession
     {
         if ([RestartableSession.GlobalVariable]::IsInRestartableSession())
         {
+            if ([RestartableSession.GlobalVariable]::OnEnd)
+            {
+                [RestartableSession.GlobalVariable]::OnEnd.Invoke([RestartableSession.GlobalVariable]::OnEndArgumentList)
+            }
             exit [RestartableSession.GlobalVariable]::kExitCodeToRestart
         }
         else

--- a/RestartableSession/Public/Start-RSRestartFileWatcher.ps1
+++ b/RestartableSession/Public/Start-RSRestartFileWatcher.ps1
@@ -81,7 +81,7 @@ function Start-RSRestartFileWatcher
             {
                 if ([RestartableSession.GlobalVariable]::OnEnd)
                 {
-                    [RestartableSession.GlobalVariable]::OnEnd.Invoke([RestartableSession.GlobalVariable]::OnEndArgumentList)
+                    [RestartableSession.GlobalVariable]::OnEnd.Invoke([RestartableSession.GlobalVariable]::OnEndArgumentList) | Write-Host
                 }
                 Stop-Process $process
             }

--- a/RestartableSession/Public/Start-RSRestartFileWatcher.ps1
+++ b/RestartableSession/Public/Start-RSRestartFileWatcher.ps1
@@ -79,6 +79,10 @@ function Start-RSRestartFileWatcher
             $process = Get-Process -Id $Event.MessageData -ErrorAction Ignore
             if ($process)
             {
+                if ([RestartableSession.GlobalVariable]::OnEnd)
+                {
+                    [RestartableSession.GlobalVariable]::OnEnd.Invoke([RestartableSession.GlobalVariable]::OnEndArgumentList)
+                }
                 Stop-Process $process
             }
         }

--- a/RestartableSession/Public/Start-RSRestartFileWatcher.ps1
+++ b/RestartableSession/Public/Start-RSRestartFileWatcher.ps1
@@ -81,7 +81,7 @@ function Start-RSRestartFileWatcher
             {
                 if ([RestartableSession.GlobalVariable]::OnEnd)
                 {
-                    [RestartableSession.GlobalVariable]::OnEnd.Invoke([RestartableSession.GlobalVariable]::OnEndArgumentList) | Write-Host
+                    [RestartableSession.GlobalVariable]::OnEnd.Invoke([RestartableSession.GlobalVariable]::OnEndArgumentList) | Out-Default
                 }
                 Stop-Process $process
             }


### PR DESCRIPTION
This PR adds `OnEnd` script block to `Enter-RSSession` that is called at the end of the RSSession.

It also adds `OnEndArgumentList` parameter and `ArgumentList` becomes an alias to `OnStartArgumentList`.